### PR TITLE
fix:fix logrus cancel trace info

### DIFF
--- a/logging/logrus/hook.go
+++ b/logging/logrus/hook.go
@@ -63,15 +63,16 @@ func (h *TraceHook) Fire(entry *logrus.Entry) error {
 
 	span := trace.SpanFromContext(entry.Context)
 
+	// non recording spans do not support modifying
+	if !span.IsRecording() {
+		return nil
+	}
+
 	// attach span context to log entry data fields
 	entry.Data[traceIDKey] = span.SpanContext().TraceID()
 	entry.Data[spanIDKey] = span.SpanContext().SpanID()
 	entry.Data[traceFlagsKey] = span.SpanContext().TraceFlags()
 
-	// non recording spans do not support modifying
-	if !span.IsRecording() {
-		return nil
-	}
 	// attach log to span event attributes
 	attrs := []attribute.KeyValue{
 		logMessageKey.String(entry.Message),


### PR DESCRIPTION
fix:fix logrus cancel trace info

修复了 logrus `ctx` 中无 trace 信息却打印出了空值的问题

以下是前后对比

![image](https://github.com/kitex-contrib/obs-opentelemetry/assets/114391708/55396008-d487-4728-bab1-f31b4b5bb317)
