### PR TITLE
feat: add zap with custom fields

### DIFF
--- a/logging/zap/logger.go
+++ b/logging/zap/logger.go
@@ -54,7 +54,7 @@ func NewLogger(opts ...Option) *Logger {
 		config.zapOpts...)
 
 	return &Logger{
-		SugaredLogger: logger.Sugar(),
+		SugaredLogger: logger.Sugar().With(config.customFields...),
 		config:        config,
 	}
 }
@@ -74,7 +74,7 @@ func (l *Logger) PutExtraKeys(keys ...ExtraKey) {
 }
 
 func (l *Logger) Log(level klog.Level, kvs ...interface{}) {
-	logger := l.With(l.config.customFields...)
+	logger := l.With()
 
 	switch level {
 	case klog.LevelTrace, klog.LevelDebug:
@@ -93,7 +93,7 @@ func (l *Logger) Log(level klog.Level, kvs ...interface{}) {
 }
 
 func (l *Logger) Logf(level klog.Level, format string, kvs ...interface{}) {
-	logger := l.With(l.config.customFields...)
+	logger := l.With()
 
 	switch level {
 	case klog.LevelTrace, klog.LevelDebug:
@@ -131,8 +131,6 @@ func (l *Logger) CtxLogf(level klog.Level, ctx context.Context, format string, k
 	} else {
 		sl = l.With()
 	}
-
-	sl = sl.With(l.config.customFields...)
 
 	if len(l.config.extraKeys) > 0 {
 		for _, k := range l.config.extraKeys {
@@ -287,7 +285,7 @@ func (l *Logger) SetOutput(writer io.Writer) {
 		l.config.zapOpts...,
 	)
 	l.config.coreConfig.ws = ws
-	l.SugaredLogger = log.Sugar()
+	l.SugaredLogger = log.Sugar().With(l.config.customFields...)
 }
 
 // Logger is used to return an instance of *zap.Logger for custom fields, etc.

--- a/logging/zap/logger.go
+++ b/logging/zap/logger.go
@@ -74,7 +74,8 @@ func (l *Logger) PutExtraKeys(keys ...ExtraKey) {
 }
 
 func (l *Logger) Log(level klog.Level, kvs ...interface{}) {
-	logger := l.With()
+	logger := l.With(l.config.customFields...)
+
 	switch level {
 	case klog.LevelTrace, klog.LevelDebug:
 		logger.Debug(kvs...)
@@ -92,7 +93,8 @@ func (l *Logger) Log(level klog.Level, kvs ...interface{}) {
 }
 
 func (l *Logger) Logf(level klog.Level, format string, kvs ...interface{}) {
-	logger := l.With()
+	logger := l.With(l.config.customFields...)
+
 	switch level {
 	case klog.LevelTrace, klog.LevelDebug:
 		logger.Debugf(format, kvs...)
@@ -129,6 +131,8 @@ func (l *Logger) CtxLogf(level klog.Level, ctx context.Context, format string, k
 	} else {
 		sl = l.With()
 	}
+
+	sl = sl.With(l.config.customFields...)
 
 	if len(l.config.extraKeys) > 0 {
 		for _, k := range l.config.extraKeys {

--- a/logging/zap/logger_test.go
+++ b/logging/zap/logger_test.go
@@ -275,6 +275,79 @@ func TestCtxKVLogger(t *testing.T) {
 	}
 }
 
+func TestWithKeyValue(t *testing.T) {
+	key := "service_name"
+	value := "kitex"
+	buf := new(bytes.Buffer)
+
+	t.Run("ctx info", func(t *testing.T) {
+		buf.Reset()
+
+		log := NewLogger(WithCustomField(key, value))
+		log.SetOutput(buf)
+
+		ctx := context.Background()
+		log.CtxInfof(ctx, "%s log", "extra")
+
+		logStructMap := make(map[string]interface{}, 0)
+
+		err := json.Unmarshal(buf.Bytes(), &logStructMap)
+		assert.Nil(t, err)
+
+		ret, ok := logStructMap[key]
+		assert.True(t, ok)
+		assert.Equal(t, value, ret)
+
+		ret, ok = logStructMap["msg"]
+		assert.True(t, ok)
+		assert.Equal(t, "extra log", ret)
+	})
+
+	t.Run("infof", func(t *testing.T) {
+		buf.Reset()
+
+		log := NewLogger(WithCustomField(key, value))
+		log.SetOutput(buf)
+
+		log.Infof("%s log", "extra")
+
+		logStructMap := make(map[string]interface{}, 0)
+
+		err := json.Unmarshal(buf.Bytes(), &logStructMap)
+		assert.Nil(t, err)
+
+		ret, ok := logStructMap[key]
+		assert.True(t, ok)
+		assert.Equal(t, value, ret)
+
+		ret, ok = logStructMap["msg"]
+		assert.True(t, ok)
+		assert.Equal(t, "extra log", ret)
+	})
+
+	t.Run("info", func(t *testing.T) {
+		buf.Reset()
+
+		log := NewLogger(WithCustomField(key, value))
+		log.SetOutput(buf)
+
+		log.Info("extra log")
+
+		logStructMap := make(map[string]interface{}, 0)
+
+		err := json.Unmarshal(buf.Bytes(), &logStructMap)
+		assert.Nil(t, err)
+
+		ret, ok := logStructMap[key]
+		assert.True(t, ok)
+		assert.Equal(t, value, ret)
+
+		ret, ok = logStructMap["msg"]
+		assert.True(t, ok)
+		assert.Equal(t, "extra log", ret)
+	})
+}
+
 // TestWithExtraKeys test WithExtraKeys option
 func TestWithExtraKeys(t *testing.T) {
 	buf := new(bytes.Buffer)

--- a/logging/zap/logger_test.go
+++ b/logging/zap/logger_test.go
@@ -275,7 +275,8 @@ func TestCtxKVLogger(t *testing.T) {
 	}
 }
 
-func TestWithKeyValue(t *testing.T) {
+// TestWithCustomFields test WithCustomFileds option.
+func TestWithCustomFields(t *testing.T) {
 	key := "service_name"
 	value := "kitex"
 	buf := new(bytes.Buffer)

--- a/logging/zap/logger_test.go
+++ b/logging/zap/logger_test.go
@@ -283,7 +283,7 @@ func TestWithKeyValue(t *testing.T) {
 	t.Run("ctx info", func(t *testing.T) {
 		buf.Reset()
 
-		log := NewLogger(WithCustomField(key, value))
+		log := NewLogger(WithCustomFields(key, value))
 		log.SetOutput(buf)
 
 		ctx := context.Background()
@@ -306,7 +306,7 @@ func TestWithKeyValue(t *testing.T) {
 	t.Run("infof", func(t *testing.T) {
 		buf.Reset()
 
-		log := NewLogger(WithCustomField(key, value))
+		log := NewLogger(WithCustomFields(key, value))
 		log.SetOutput(buf)
 
 		log.Infof("%s log", "extra")
@@ -328,7 +328,7 @@ func TestWithKeyValue(t *testing.T) {
 	t.Run("info", func(t *testing.T) {
 		buf.Reset()
 
-		log := NewLogger(WithCustomField(key, value))
+		log := NewLogger(WithCustomFields(key, value))
 		log.SetOutput(buf)
 
 		log.Info("extra log")

--- a/logging/zap/option.go
+++ b/logging/zap/option.go
@@ -105,10 +105,10 @@ func WithCoreLevel(lvl zap.AtomicLevel) Option {
 	})
 }
 
-// WithCustomField record log with the key-value pair.
-func WithCustomField(k string, v interface{}) Option {
+// WithCustomFields record log with the key-value pair.
+func WithCustomFields(kv ...interface{}) Option {
 	return option(func(cfg *config) {
-		cfg.customFields = append(cfg.customFields, k, v)
+		cfg.customFields = append(cfg.customFields, kv...)
 	})
 }
 

--- a/logging/zap/option.go
+++ b/logging/zap/option.go
@@ -45,6 +45,7 @@ type traceConfig struct {
 }
 
 type config struct {
+	customFields  []interface{}
 	extraKeys     []ExtraKey
 	coreConfig    coreConfig
 	zapOpts       []zap.Option
@@ -79,6 +80,7 @@ func defaultConfig() *config {
 		},
 		zapOpts:       []zap.Option{},
 		extraKeyAsStr: false,
+		customFields:  []interface{}{},
 	}
 }
 
@@ -100,6 +102,13 @@ func WithCoreWs(ws zapcore.WriteSyncer) Option {
 func WithCoreLevel(lvl zap.AtomicLevel) Option {
 	return option(func(cfg *config) {
 		cfg.coreConfig.lvl = lvl
+	})
+}
+
+// WithCustomField record log with the key-value pair.
+func WithCustomField(k string, v interface{}) Option {
+	return option(func(cfg *config) {
+		cfg.customFields = append(cfg.customFields, k, v)
 	})
 }
 


### PR DESCRIPTION
### summary

I use klog implemented by zap, but klog-zap can't input custom params.

e.g. klog can record inputed server_name and server_version ? 

**expect**

```
package main

import (
    "github.com/cloudwego/kitex/pkg/klog"
    kitexzap "github.com/kitex-contrib/obs-opentelemetry/logging/zap"
)

func main() {
    klog.SetLogger(kitexzap.NewLogger(kitexzap.WithCustomFields("service_name", "kitex", "version": "v1.0.1", "tags": "cloud.k8s")))
    klog.SetLevel(klog.LevelDebug)

    ...
    ...
}
```